### PR TITLE
Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
 
+ENV AWS_DEFAULT_REGION us-east-1
+
 RUN apt-get update -q
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy python-pip groff-base
 RUN pip install awscli
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,5 @@ ENV AWS_DEFAULT_REGION us-east-1
 RUN apt-get update -q
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy python-pip groff-base
 RUN pip install awscli
+
+ENTRYPOINT ["/usr/local/bin/aws"]


### PR DESCRIPTION
By using an entrypoint the container can be used in place of the `awscli` command, which is the goal here, right?
